### PR TITLE
Update Chord.cpp

### DIFF
--- a/src/Chord.cpp
+++ b/src/Chord.cpp
@@ -87,7 +87,7 @@ struct Chord : Module {
 	Chord() {
     config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
 
-    configParam(OFFSET_PARAM, 0.0, 1.0, 0.0,"Offset");
+    configParam(OFFSET_PARAM, 0.0, 1.0, 0.5,"Offset");
     configParam(INVERSION_PARAM, 0.0, 1.0, 0.0,"Inversion");
     configParam(VOICING_PARAM, 0.0, 1.0, 0.0,"Voicing");
     configParam(OFFSET_AMT_PARAM, 0.0, 1.0, 0.5,"Offset Amt");


### PR DESCRIPTION
changes the initialize value for offset in chord to ensure the root note output is the same as the input v/oct instead of half an octave down